### PR TITLE
fix(norm): normalize_quantiles pass

### DIFF
--- a/qtl/norm.py
+++ b/qtl/norm.py
@@ -32,7 +32,7 @@ def normalize_quantiles(df):
 
     for i in range(n):
         # Get equivalence classes; unique values == 0
-        dupes = np.zeros(m, dtype=np.int)
+        dupes = np.zeros(m, dtype=int)
         for j in range(m-1):
             if M[Q[j,i],i] == M[Q[j+1,i],i]:
                 dupes[j+1] = dupes[j]+1


### PR DESCRIPTION
related to: #5 


tested using:
```
import pandas as pd
from qtl.norm import normalize_quantiles
a = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
normalize_quantiles(a)
   A  B
0  2  2
1  3  3
```